### PR TITLE
Add run_simulation.py CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ Make sure MuJoCo is installed and licensed correctly on your system.
 
 - **Simulation & Testing:**  
   Use the provided scripts (`main_linear_only.py`, `mujoco_lqr_controller_interactive.py`, `mujoco_linear_control.py`, `nn_mujoco.py`) to simulate and compare the performance of the different controllers in both differentiable and real-time MuJoCo environments.
+  Alternatively, run `run_simulation.py` and select the desired controller via command-line flags for a unified interface.  For example:
+  ```bash
+  python run_simulation.py --controller nn            # run the NN controller
+  python run_simulation.py --controller nn --mode train  # train the NN
+  ```
 
 - **Visualization:**  
   Utility functions in `lib/utils.py` enable plotting of trajectories, energy profiles, and cost comparisons.

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,3 @@
+model_xml: cart_pole.xml
+sim_duration: 30.0
+nn_model_path: saved_models/nn_controller.eqx

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -1,0 +1,83 @@
+"""Unified command-line runner for Cart-Pole simulations."""
+
+import argparse
+import importlib
+import os
+import sys
+from typing import Dict
+
+import yaml
+
+
+def load_config(path: str) -> dict:
+    """Load simulation configuration from YAML file."""
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"Config file '{path}' not found")
+    with open(path, 'r') as f:
+        return yaml.safe_load(f)
+
+
+def run_module(module_name: str, env: Dict[str, str]) -> None:
+    """Import ``module_name`` and execute its ``main`` function if present."""
+    os.environ.update(env)
+
+    if module_name.endswith(".py"):
+        module_name = module_name[:-3]
+
+    if module_name not in sys.modules:
+        module = importlib.import_module(module_name)
+    else:
+        module = importlib.reload(sys.modules[module_name])
+
+    if hasattr(module, "main") and callable(module.main):
+        module.main()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Unified CartPole simulation runner")
+    parser.add_argument(
+        "--controller",
+        choices=["nn", "linear", "lqr", "lqr-interactive"],
+        required=True,
+        help="Controller type to run",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["simulate", "train"],
+        default="simulate",
+        help="Execution mode (if applicable)",
+    )
+    parser.add_argument(
+        "--config",
+        default="config.yaml",
+        help="Path to YAML configuration file",
+    )
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+
+    # Environment variables for child scripts
+    env = os.environ.copy()
+    env.update({
+        "MODEL_XML": str(config.get("model_xml", "cart_pole.xml")),
+        "SIM_DURATION": str(config.get("sim_duration", 30.0)),
+        "NN_MODEL_PATH": str(config.get("nn_model_path", "saved_models/nn_controller.eqx")),
+    })
+
+    if args.controller == "nn":
+        if args.mode == "train":
+            run_module("train_nn_controller", env)
+        else:
+            run_module("nn_mujoco", env)
+    elif args.controller == "linear":
+        run_module("mujoco_linear_control", env)
+    elif args.controller == "lqr":
+        run_module("mujoco_lqr_controller", env)
+    elif args.controller == "lqr-interactive":
+        run_module("mujoco_lqr_controller_interactive", env)
+    else:
+        raise ValueError(f"Unknown controller type '{args.controller}'")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_simulation.py` as a unified command-line runner
- store default parameters in `config.yaml`
- document new CLI in README

## Testing
- `python -m py_compile run_simulation.py`
- `pytest -q`