### PR TITLE
Introduce unified configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,24 @@
 model_xml: cart_pole.xml
 sim_duration: 30.0
+time_step: 0.01
 nn_model_path: saved_models/nn_controller.eqx
+
+nn_training:
+  params_system: [1.0, 0.1, 0.5, 9.81]
+  q_weights: [0.1, 10.0, 10.0, 0.1, 0.1]
+  num_epochs: 500
+  batch_size: 32
+  t_span: [0.0, 10.0]
+  t_eval_points: 100
+  learning_rate: 3e-4
+  grad_clip: 1.0
+
+linear_training:
+  lr: 1e-4
+  max_iters: 100
+  tolerance: 1e-6
+  w_init: [10.7477045, -0.00142533379, -95.3456802, 13.2174416, -27.8421364]
+
+lqr:
+  Q: [50.0, 100.0, 5.0, 20.0]
+  R: 0.1

--- a/mujoco_lqr_controller.py
+++ b/mujoco_lqr_controller.py
@@ -6,6 +6,8 @@ import jax.numpy as jnp
 import matplotlib.pyplot as plt
 import time
 import warnings
+import os
+import yaml
 
 # MuJoCo + viewer
 import mujoco
@@ -13,6 +15,10 @@ import mujoco_viewer
 
 # Import your LQR helpers
 from controller.lqr_controller import linearize_cartpole, compute_lqr_gain
+
+CONFIG_PATH = os.environ.get("CONFIG_PATH", "config.yaml")
+with open(CONFIG_PATH, "r") as f:
+    _CFG = yaml.safe_load(f) or {}
 
 warnings.filterwarnings("ignore", category=UserWarning, module="glfw")
 
@@ -39,7 +45,7 @@ print("LQR gain K =", K)
 ###############################################################################
 # 2. Load MuJoCo Model
 ###############################################################################
-XML_FILE = "cart_pole.xml"
+XML_FILE = os.environ.get("MODEL_XML", _CFG.get("model_xml", "cart_pole.xml"))
 with open(XML_FILE, "r") as f:
     xml_str = f.read()
 
@@ -114,7 +120,7 @@ viewer.render()
 time.sleep(2)
 
 sim_time = 0.0
-sim_duration = 30.0
+sim_duration = float(os.environ.get("SIM_DURATION", _CFG.get("sim_duration", 30.0)))
 start_time = time.time()
 
 time_log = []

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -54,11 +54,13 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    config = load_config(args.config)
+    config_path = os.path.abspath(args.config)
+    config = load_config(config_path)
 
     # Environment variables for child scripts
     env = os.environ.copy()
     env.update({
+        "CONFIG_PATH": config_path,
         "MODEL_XML": str(config.get("model_xml", "cart_pole.xml")),
         "SIM_DURATION": str(config.get("sim_duration", 30.0)),
         "NN_MODEL_PATH": str(config.get("nn_model_path", "saved_models/nn_controller.eqx")),


### PR DESCRIPTION
## Summary
- extend `config.yaml` with simulation, training, and controller parameters
- propagate config path and values through `run_simulation.py`
- load configuration in `train_nn_controller.py` and use it for hyperparameters
- load configuration in real-time scripts (`nn_mujoco.py`, `mujoco_linear_control.py`, `mujoco_lqr_controller.py`)

## Testing
- `python -m py_compile $(git ls-files '*.py')`